### PR TITLE
Add optional value_only param for flattened proof generation

### DIFF
--- a/solidity_merkletools/__init__.py
+++ b/solidity_merkletools/__init__.py
@@ -95,12 +95,12 @@ class MerkleTools(object):
         else:
             return None
 
-    def get_proof_for_value(self, value):
+    def get_proof_for_value(self, value, value_only=False):
         idx = self.get_index(value)
         if idx is None:
             return []
 
-        return self.get_proof(idx)
+        return self.get_proof(idx, value_only)
 
     def get_proof(self, index, value_only=False):
         if self.levels is None:


### PR DESCRIPTION
By adding the `value_only` param we are able to generate a flattened version of the proof.

This option is needed to make the proof compatible with Open Zeppelin's MerkleProof validation method.

https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/MerkleProof.sol#L69-L75
https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/MerkleProof.sol#L211-L213